### PR TITLE
Fixed the installation folder path

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 Install this extension either as
 
- ~/.local/share/gnome-shell/extensions/org.gnome.desktop-icons
+ ~/.local/share/gnome-shell/extensions/org.gnome-shell.desktop-icons
 
 or as
 


### PR DESCRIPTION
The extension does not properly start if the folder is not named "org.gnome-shell.desktop-icons" since GNOME checks if the folder is the same as the UUID of the extension in the manifest.json