### PR TITLE
Quick and dirty fix for a null object (file) crash

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -791,8 +791,15 @@ const DesktopManager = new Lang.Class(
         while ((info = fileEnum.next_file(null)))
         {
             let file = fileEnum.get_child(info);
-            let fileContainer = new FileContainer(file, info);
-            this._fileContainers.push(fileContainer);
+            if(file!=null)
+            {
+              let fileContainer = new FileContainer(file, info);
+              this._fileContainers.push(fileContainer);	
+            }
+            else
+            {
+              log("Skipping unexpected null file");
+            }
         }
 
         this._desktopContainers.forEach(Lang.bind(this,


### PR DESCRIPTION
I'm not entirely sure I should post this as a pull request, since I didn't investigate why the fileEnum contains a null item. If you find the fix not to be constructive just consider it as a bug report.